### PR TITLE
Bpm analyzer improvements

### DIFF
--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -327,10 +327,10 @@ double BeatUtils::calculateBpm(const QVector<double>& beats, int SampleRate,
     // and therefore most likely should have a perfect round number as bpm
     // test if 2/3, 3/2 or 2/1 creates a bpm which is a whole number in reason
     const bool near_integer = fabs(round(perfectAverageBpm) - perfectAverageBpm) <= kRoundFactor;
-    double avarageTampoDeviation = computeAverageTempoDeviation(beats, SampleRate);
-    qDebug() << "avarageTampoDeviation=" << avarageTampoDeviation;
+    double avarageTempoDeviation = computeAverageTempoDeviation(beats, SampleRate);
+    qDebug() << "avarageTampoDeviation=" << avarageTempoDeviation;
 
-    if (!near_integer && avarageTampoDeviation <= kMinMachineTempoDeviaton) {
+    if (!near_integer && avarageTempoDeviation <= kMinMachineTempoDeviaton) {
         const double bpm_32 = perfectAverageBpm * 3.0/2.0;
         const double bpm_23 = perfectAverageBpm * 2.0/3.0;
         const double bpm_21 = perfectAverageBpm * 2.0;

--- a/src/track/beatutils.h
+++ b/src/track/beatutils.h
@@ -36,7 +36,6 @@ class BeatUtils {
 
         return bpm;
     }
-
     static double isNearInteger(double bpm, const double epsilon, const double minBPM, const double maxBPM) {
         return bpm >= minBPM && bpm <= maxBPM && fabs(bpm - round(bpm)) <= epsilon;
     };
@@ -81,6 +80,8 @@ class BeatUtils {
     static QList<double> computeWindowedBpmsAndFrequencyHistogram(
         const QVector<double> beats, const int windowSize, const int windowStep,
         const int sampleRate, QMap<double, int>* frequencyHistogram);
+    static double computeAverageTempoDeviation(
+            const QVector<double> beats, const int SampleRate);
 
 };
 


### PR DESCRIPTION
Calculate the absolute deviation of beat positions and only try to round bpm on electronic music, where the deviation should be very close to 0